### PR TITLE
Fixed setup.py installation script and packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='clockify_cli',
     version='0.10',
-    py_modules=['clockify_cli'],
+    # py_modules=['clockify_cli'],
+    packages=find_packages(include=['clockify_cli']),
     author='Theodore Hu',
     url='https://github.com/t5/clockify-cli',
     install_requires=[


### PR DESCRIPTION
Heyo! 

I had a problem getting the script to work from the CLI on my machine. With the old code, after executing 

```
pip install .
````

in a fresh virtual environment I got the following error: 

```
$ clockify --help
Traceback (most recent call last):
  File "/Users/kyle/.virtualenvs/clockify/bin/clockify", line 6, in <module>
    from clockify_cli.clockify_cli import main
ModuleNotFoundError: No module named 'clockify_cli'
```

My simple changes fix this issue. You just needed to tweak the setup.py file a bit and add an `__init__.py` file to your package directory to make it a proper module. 